### PR TITLE
fix: default home url to root path

### DIFF
--- a/src/api/flaskr/route/config.py
+++ b/src/api/flaskr/route/config.py
@@ -105,7 +105,7 @@ def register_config_handler(app: Flask, path_prefix: str) -> Flask:
             "defaultLoginMethod": get_config("DEFAULT_LOGIN_METHOD", "phone"),
             "googleOauthRedirect": f"{origin}/login/google-callback",
             # Redirect Configuration
-            "homeUrl": get_config("HOME_URL", ""),
+            "homeUrl": get_config("HOME_URL", "/"),
             "currencySymbol": get_config("CURRENCY_SYMBOL", "¥"),
             # Legal Documents Configuration
             "legalUrls": legal_urls,

--- a/src/cook-web/src/app/page.tsx
+++ b/src/cook-web/src/app/page.tsx
@@ -15,7 +15,7 @@ export default function Home() {
     if (!runtimeConfigLoaded) {
       return;
     }
-    redirectToHomeUrlIfRootPath(homeUrl);
+    redirectToHomeUrlIfRootPath(homeUrl || '/');
   }, [homeUrl, runtimeConfigLoaded]);
 
   return (

--- a/src/cook-web/src/c-components/logo/LogoWithText.tsx
+++ b/src/cook-web/src/c-components/logo/LogoWithText.tsx
@@ -50,9 +50,9 @@ export const LogoWithText = ({ direction, size = 64 }) => {
       }}
     >
       <a
-        href={homeUrl || undefined}
-        target={homeUrl ? '_blank' : undefined}
-        rel={homeUrl ? 'noreferrer' : undefined}
+        href={homeUrl || '/'}
+        target={homeUrl && homeUrl !== '/' ? '_blank' : undefined}
+        rel={homeUrl && homeUrl !== '/' ? 'noreferrer' : undefined}
       >
         <div
           style={{

--- a/src/cook-web/src/config/environment.ts
+++ b/src/cook-web/src/config/environment.ts
@@ -304,7 +304,7 @@ function getDefaultLoginMethod(): string {
  * Gets home URL
  */
 function getHomeUrl(): string {
-  return getRuntimeEnv('HOME_URL') || process.env.HOME_URL || '';
+  return getRuntimeEnv('HOME_URL') || process.env.HOME_URL || '/';
 }
 
 /**

--- a/src/cook-web/src/lib/initializeEnvData.ts
+++ b/src/cook-web/src/lib/initializeEnvData.ts
@@ -178,7 +178,7 @@ const loadRuntimeConfig = async () => {
     runtimeConfig?.enableWechatCode?.toString() || 'true',
   );
   await updateDefaultLlmModel(runtimeConfig?.defaultLlmModel || '');
-  await updateHomeUrl(runtimeConfig?.homeUrl || '');
+  await updateHomeUrl(runtimeConfig?.homeUrl || '/');
   await updateCurrencySymbol(runtimeConfig?.currencySymbol || '¥');
   await updateStripePublishableKey(runtimeConfig?.stripePublishableKey || '');
   await updateStripeEnabled(


### PR DESCRIPTION
## Summary
- default backend HOME_URL to `/`
- default frontend HOME_URL fallback to `/`
- keep logo click and root-page redirect aligned with `/`

## Testing
- pre-commit run --files src/api/flaskr/route/config.py src/cook-web/src/app/page.tsx src/cook-web/src/c-components/logo/LogoWithText.tsx src/cook-web/src/config/environment.ts src/cook-web/src/lib/initializeEnvData.ts